### PR TITLE
adjust Dutch language file

### DIFF
--- a/languages/dutch/wordlist_dutch_netherlands.csv
+++ b/languages/dutch/wordlist_dutch_netherlands.csv
@@ -1,6 +1,6 @@
 PromptName,PromptSpeechPrefix,PromptSpeechPostfix,PromptText
 PROMPT_SPACE,,, 
-PROMPT_POINT,,,POINT
+PROMPT_POINT,,,PUNT
 PROMPT_0,,,0
 PROMPT_1,,,1
 PROMPT_2,,,2
@@ -36,14 +36,14 @@ PROMPT_V,,,V
 PROMPT_W,,,W
 PROMPT_X,,,X
 PROMPT_Y,,,Y
-PROMPT_Z,,,Zed
+PROMPT_Z,,,Z
 PROMPT_Z2,,,Z
 PROMPT_CHANNEL,,,Kanaal
 PROMPT_CONTACT,,,Contact
-PROMPT_DBM,,,D B M
-PROMPT_ENTRY,,,Binnenkomst
-PROMPT_MEGAHERTZ,,,Megahertz
-PROMPT_KILOHERTZ,,,Kilohertz
+PROMPT_DBM,,,D; B; M
+PROMPT_ENTRY,,,Ingave
+PROMPT_MEGAHERTZ,,,Megaherts
+PROMPT_KILOHERTZ,,,Kilo herts
 PROMPT_TALKGROUP,,,Gespreksgroep
 PROMPT_TIMESLOT,,,Tijdslot
 PROMPT_VFO,,,V F O
@@ -51,14 +51,14 @@ PROMPT_SECONDS,,,Seconden
 PROMPT_Minutes,,,Minuten
 PROMPT_Hours,,,Uren
 PROMPT_VOLTS,,,Volt
-PROMPT_WATT,,,Wattt
-PROMPT_WATTS,,,Watts
+PROMPT_WATT,,,Watt
+PROMPT_WATTS,,,Watt
 PROMPT_MILLIWATTS,,,Milliwatt
 PROMPT_PERCENT,,,Procent
-PROMPT_RECEIVE,,,Te ontvangen
+PROMPT_RECEIVE,,,Ontvangen
 PROMPT_Transmit,,,Zenden
 PROMPT_HASH,,,Hash
-PROMPT_STAR,,,Begin
+PROMPT_STAR,,,Ster
 PROMPT_GREEN,,,Groen
 PROMPT_RED,,,Rood
 PROMPT_VERSION,,,Versie
@@ -68,19 +68,19 @@ PROMPT_FM,,,F M
 PROMPT_WIDE,,,Breed
 PROMPT_NARROW,,,Smal
 PROMPT_PLUS,,,Plus
-PROMPT_MINUS,,,Minus
-PROMPT_VFO_EXCHANGE_TX_RX,,,Wissel Tx- en Rx-frequenties uit
-PROMPT_VFO_COPY_RX_TO_TX,,,Kopieer de ontvangstfrequentie naar de verzendfrequentie
-PROMPT_VFO_COPY_TX_TO_RX,,,Kopieer de verzendfrequentie naar de ontvangstfrequentie
-PROMPT_POWER,,,kracht
+PROMPT_MINUS,,,Min
+PROMPT_VFO_EXCHANGE_TX_RX,,,Wissel Zend en Ontvangstfrequenties Om
+PROMPT_VFO_COPY_RX_TO_TX,,,Kopieer de Ontvangstfrequentie naar de Zendfrequentie
+PROMPT_VFO_COPY_TX_TO_RX,,,Kopieer de Zendfrequentie naar de Ontvangstfrequentie
+PROMPT_POWER,,,Vermogen
 PROMPT_CHANNEL_MODE,,,kanaalmodus
 PROMPT_SCAN_MODE,,,scanmodus
 PROMPT_TIMESLOT_MODE,,,tijdslotmodus
 PROMPT_FILTER_MODE,,,filtermodus
 PROMPT_ZONE_MODE,,,zonemodus
-PROMPT_POWER_MODE,,,power modus
-PROMPT_COLORCODE_MODE,,,kleurcodemodus
-PROMPT_HERTZ,,,hertz
+PROMPT_POWER_MODE,,,vermogen modus
+PROMPT_COLORCODE_MODE,,,kleurkode modus
+PROMPT_HERTZ,,,Herts
 PROMPT_TBD2,,,
 PROMPT_TBD3,,,
 PROMPT_TBD4,,,
@@ -108,137 +108,137 @@ rssi,,,Veldsterkte
 battery,,,Batterij
 contacts,,,Contacten
 last_heard,,,Laatst gehoord
-firmware_info,,,Firmware info
-options,,,Opties
-display_options,,,Scherm opties
-sound_options,,,Geluid opties
+firmware_info,,,Fuirmwijr  Informatie
+options,,,Instellingen
+display_options,,,Instellingen Scherm
+sound_options,,,Instellingen Geluid
 channel_details,,,Kanaal details
 language,,,Taal
-new_contact,,,Nieuw contact
+new_contact,,,Nieuw Contact
 contact_list,,,Contactlijst
 contact_details,,,Contact Details
-hotspot_mode,,,Hotspot   
+hotspot_mode,,,Hotspot modus
 built,,,Gemaakt
 zones,,,Zones
 keypad,,,Toetsenbord
-ptt,,,PTT
+ptt,,,P T T
 locked,,,Vergrendeld
-press_blue_plus_star,,,Druk Blauw + *
+press_blue_plus_star,,,Druk Blauw + ster
 to_unlock,,,om te ontgrendelen
 unlocked,,,Ontgrendeld
 power_off,,,Uitschakelen ...
 error,,,FOUT
-rx_only,,,Alleen Rx
+rx_only,,,Alleen Ontvangst
 out_of_band,,,BUITEN BAND
-timeout,,,TIME-OUT
-tg_entry,,,TG invoeren
-pc_entry,,,PO invoeren
-user_dmr_id,,,DMRID Gebruiker
+timeout,,,Taaimout
+tg_entry,,,Gespreksgroep invoeren
+pc_entry,,,Private oproep invoeren
+user_dmr_id,,,D M R I D; van Gebruiker
 contact,,,Contact
 accept_call,,,Oproep aannemen?
 private_call,,,Private Oproep
-squelch,,,Squelch
+squelch,,,Skwelsj
 quick_menu,,,Snelmenu
 filter,,,Filter
 all_channels,,,Alle Kanalen
-gotoChannel,,,Ga Naar
+gotoChannel,,,Ga Naar Kanaaaal
 scan,,,Scan
-channelToVfo,,,Kanaal --> VFO
-vfoToChannel,,,VFO --> Kanaal
-vfoToNewChannel,,,VFO-->Nieuw Kan.
+channelToVfo,,,Kanaal naar V F O
+vfoToChannel,,,V F O Naar Kanaal
+vfoToNewChannel,,,V F O Naar Nieuw Kanaal
 group,,,Groep
 private,,,Privaat
 all,,,Alle
 type,,,Type
-timeSlot,,,Tijdslot  
+timeSlot,,,Tijdslot
 none,,,Geen
 contact_saved,,,Contact Bewaard
 duplicate,,,Dubbel
-tg,,,TG
-pc,,,PO
-ts,,,TS
-mode,,,Mode    
-colour_code,,,Color Code
-n_a,,,nvt
+tg,,,Gespreksgroep
+pc,,,Private Oproep
+ts,,,Tijdslot
+mode,,,Modus  
+colour_code,,,Kleur Kode
+n_a,,,niet van toepassing
 bandwidth,,,Bandbreedte
-stepFreq,,,Stap  
-tot,,,TOT   
+stepFreq,,,Frequentie Stap  
+tot,,,Zendtijd Begrenzing
 off,,,Uit
-zone_skip,,,Zone Oversl
-all_skip,,,Alles Overs
+zone_skip,,,Zone Overslaan
+all_skip,,,Alles Overslaan
 yes,,,Ja
 no,,,Neen
-rx_group,,,Rx Grp
+rx_group,,,Ontvangstgroep
 on,"<emphasis level=""strong"">",</emphasis>,Aan
-timeout_beep,,,Timeout piep
-factory_reset,,,Fact Reset
-calibration,,,Calibratie
-band_limits,,,Band Lim. 
+timeout_beep,,,Taaimout piep
+factory_reset,,,Fabrieksinstellingen
+calibration,,,Calibraasssie
+band_limits,,,Band Limieten
 beep_volume,,,Piepvolume
-dmr_mic_gain,,,DMR mic   
-fm_mic_gain,,,FM mic    
-key_long,,,Toets lang
-key_repeat,,,Toets herh
-dmr_filter_timeout,,,Filter tijd
+dmr_mic_gain,,,D M R microfoonversterking
+fm_mic_gain,,,F M microfoonversterking
+key_long,,,Toets Drukken Lang
+key_repeat,,,Toets Herhalen
+dmr_filter_timeout,,,Filter Tijd
 brightness,,,Helderheid 
-brightness_off,,,Min helderh
+brightness_off,,,Minimum Helderheid
 contrast,,,Contrast   
-colour_invert,,,Omkeren
+colour_invert,,,Omgekeerd
 colour_normal,,,Normaal
-backlight_timeout,,,Timeout 
-scan_delay,,,Scan vertr.
+backlight_timeout,,,Taaimout Achtergrondverlichting
+scan_delay,,,Scan Vertraging
 yes___in_uppercase,,,JA
 no___in_uppercase,,,NEEN
 DISMISS,,,AFWIJZEN
-scan_mode,,,Scan mode
+scan_mode,,,Scan Modus
 hold,,,Houden
 pause,,,Pauze
-empty_list,,,Lijst Leegmaken
-delete_contact_qm,,,Wis contact?
+empty_list,,,Lijstttt Leegmaken
+delete_contact_qm,,,Contact wissen?
 contact_deleted,,,Contact gewist
 contact_used,,,Contact gebruikt
-in_rx_group,,,in de Rx groep
-select_tx,,,Zet als Tx
+in_rx_group,,,in de Ontvangst Groep
+select_tx,,,Kies Als Contact
 edit_contact,,,Bewerk Contact
 delete_contact,,,Wis Contact
 group_call,,,Groepsoproep
-all_call,,,Iedereen Roepen
-tone_scan,,,Toon scan
-low_battery,,,BATTERY LEEG!!!
-Auto,,,Auto
+all_call,,,Iedereen Oproepen
+tone_scan,,,Toon Scan
+low_battery,,,BATTERIJ LEEG!!!
+Auto,,,Automatisch
 manual,,,Manueel
-ptt_toggle,,,PTT latch 
-private_call_handling,,,Sta PO toe
+ptt_toggle,,,P T T bistabiel
+private_call_handling,,,Sta Private Oproep Toe
 stop,,,Stop
 one_line,,,1 lijn
 two_lines,,,2 lijnen
-new_channel,,,Nw kanaal
-priority_order,,,Volgord
-dmr_beep,,,DMR piep  
+new_channel,,,Nieuw Kanaal
+priority_order,,,Volgorde
+dmr_beep,,,D M R piep  
 start,,,Start
 both,,,Beide
-vox_threshold,,,VOX Drempel
-vox_tail,,,VOX Duur   
-audio_prompt,,,Melding 
+vox_threshold,,,Voks Drempel
+vox_tail,,,Voks Duur   
+audio_prompt,,,Meldingen
 silent,,,Stil
 normal,,,Normaal
 beep,,,Piep
-voice_prompt_level_1,,,Stem
-transmitTalkerAlias,,,TA zenden 
-squelch_VHF,,,VHF Squelch
-squelch_220,,,220 Squelch
-squelch_UHF,,,UHF Squelch
-display_background_colour,,,Kleur  
-openGD77,,,OpenGD77
-openGD77S,,,OpenGD77S
-openDM1801,,,OpenDM1801
-openRD5R,,,OpenRD5R
+voice_prompt_level_1,,,Stem Niveau 1
+transmitTalkerAlias,,,Talker Alias Uitzenden 
+squelch_VHF,,,V H F Skwelsj
+squelch_220,,,220 Meega Herts Skwelsj
+squelch_UHF,,,U H F Skwelsj
+display_background_colour,,,Scherm achtergrond 
+openGD77,,,Open G D 77
+openGD77S,,,Open G D 77S
+openDM1801,,,Open D M 1801
+openRD5R,,,Open R D 5 R
 gitCommit,,,Git commit
-voice_prompt_level_2,,,Stem L2
-voice_prompt_level_3,,,Stem L3
-dmr_filter,,,DMR Filter
-dmr_cc_filter,,,CC Filter 
-dmr_ts_filter,,,TS Filter 
-dtmf_contact_list,,,DTMF lijst
-channel_power,,,Kn kracht
-master_power,,,Master
+voice_prompt_level_2,,,Stem Niveau 2
+voice_prompt_level_3,,,Stem Niveau 3
+dmr_filter,,,D M R Filter
+dmr_cc_filter,,,Kleurkode Filter 
+dmr_ts_filter,,,Tijdslot Filter 
+dtmf_contact_list,,,D T M F lijst
+channel_power,,,Vermogen voor Kanaal
+master_power,,,Algemeen vermogen


### PR DESCRIPTION
Some words may seem misspelled, but this is to get an acceptable speech output. 
Especially some (intentionally untranslated) English words needed this to get a reasonable pronunciation.